### PR TITLE
remove dingtalk init in httpJob.js

### DIFF
--- a/Hangfire.HttpJob/Content/httpjob.js
+++ b/Hangfire.HttpJob/Content/httpjob.js
@@ -127,18 +127,7 @@
                 Mail: "",
                 CallbackEL: ""
             };
-            if (config.EnableDingTalk && config.EnableDingTalk == 'true') {
-                normalObj.DingTalk = {
-                    Token: config.DingtalkToken||"",
-                    AtPhones: config.DingtalkPhones||"",
-                    IsAtAll: config.DingtalkAtAll == 'true' ? true : false
-                }
-                recurringObj.DingTalk = {
-                    Token: config.DingtalkToken || "",
-                    AtPhones: config.DingtalkPhones||"",
-                    IsAtAll: config.DingtalkAtAll == 'true'?true:false
-                }
-            }
+           
             var normal_templete = JSON.stringify(normalObj);     // "{\"JobName\":\"\",\"Method\":\"GET\",\"ContentType\":\"application/json\",\"Url\":\"http://\",\"DelayFromMinutes\":1,\"Headers\":{},\"Data\":{},\"Timeout\":" + config.GlobalHttpTimeOut + ",\"BasicUserName\":\"\",\"BasicPassword\":\"\",\"QueueName\":\"" + config.DefaultBackGroundJobQueueName + "\",\"EnableRetry\":false,\"RetryTimes\":3,\"RetryDelaysInSeconds\":\"20,30,60\",\"SendSucMail\":false,\"SendFaiMail\":true,\"Mail\":\"\",\"AgentClass\":\"\",\"CallbackEL\":\"\"}";
             var recurring_templete = JSON.stringify(recurringObj); // "{\"JobName\":\"\",\"Method\":\"GET\",\"ContentType\":\"application/json\",\"Url\":\"http://\",\"Headers\":{},\"Data\":{},\"Timeout\":" + config.GlobalHttpTimeOut + ",\"Cron\":\"\",\"BasicUserName\":\"\",\"BasicPassword\":\"\",\"QueueName\":\"" + config.DefaultRecurringQueueName + "\",\"EnableRetry\":false,\"RetryTimes\":3,\"RetryDelaysInSeconds\":\"20,30,60\",\"SendSucMail\":false,\"SendFaiMail\":true,\"Mail\":\"\",\"AgentClass\":\"\",\"CallbackEL\":\"\"}";
             // console.log(normal_templete);


### PR DESCRIPTION
我觉的如果用httpAgent 来维护任务的话， 那调度这边 就不需要配置 DingTalk 了， 只要一个全局的调度推送即可。 【mail 同理 都在HttpAgent 那边处理】