### PR TITLE
错误的lazy用法

### DIFF
--- a/Server/Hangfire.HttpJob/Server/HttpJob.cs
+++ b/Server/Hangfire.HttpJob/Server/HttpJob.cs
@@ -508,7 +508,7 @@ namespace Hangfire.HttpJob.Server
                 var subject = $"【JOB】[Success]" + item.JobName+(!string.IsNullOrEmpty(item.RecurringJobIdentifier)?"-"+item.RecurringJobIdentifier : "");
                 result = result.Replace("\n", "<br/>");
                 result = result.Replace("\r\n", "<br/>");
-                EmailService.Instance.Send(mail, subject, result);
+                new EmailService().Send(mail, subject, result);
             }
             catch (Exception ex)
             {
@@ -540,7 +540,7 @@ namespace Hangfire.HttpJob.Server
                     result += BuildExceptionMsg(exception);
                 }
 
-                EmailService.Instance.Send(mail, subject, result);
+               new EmailService().Send(mail, subject, result);
             }
             catch (Exception ex)
             {

--- a/Server/Hangfire.HttpJob/Support/EmailService.cs
+++ b/Server/Hangfire.HttpJob/Support/EmailService.cs
@@ -14,12 +14,6 @@ namespace Hangfire.HttpJob.Support
     public class SmtpOptions
     {
         private static readonly ILog Logger = LogProvider.For<SmtpOptions>();
-        public SmtpClient SmtpClient => lazySmtpClient().Value;
-
-        private Lazy<SmtpClient> lazySmtpClient()
-        {
-            return new Lazy<SmtpClient>(InitSmtpClient);
-        }
         public string Server { get; set; } = string.Empty;
         public int Port { get; set; } = 25;
         public string User { get; set; } = string.Empty;
@@ -69,33 +63,16 @@ namespace Hangfire.HttpJob.Support
         private static readonly ILog Logger = LogProvider.For<EmailService>();
         private readonly SmtpOptions SmtpOptions;
 
-        static EmailService InitEmailService()
+        public EmailService()
         {
-            return new EmailService(new SmtpOptions
+            SmtpOptions = new SmtpOptions
             {
                 Server = CodingUtil.HangfireHttpJobOptions.MailOption.Server,
                 Port = CodingUtil.HangfireHttpJobOptions.MailOption.Port,
                 UseSsl = CodingUtil.HangfireHttpJobOptions.MailOption.UseSsl,
                 User = CodingUtil.HangfireHttpJobOptions.MailOption.User,
                 Password = CodingUtil.HangfireHttpJobOptions.MailOption.Password
-            });
-        }
-
-        public static EmailService Instance => lazySmtpClient().Value;
-
-        private static Lazy<EmailService> lazySmtpClient()
-        {
-            return new Lazy<EmailService>(InitEmailService);
-        }
-
-        private EmailService()
-        {
-        }
-      
-
-        private EmailService(SmtpOptions _smtpOptions)
-        {
-            SmtpOptions = _smtpOptions;
+            };
         }
 
         /// <summary>
@@ -303,7 +280,7 @@ namespace Hangfire.HttpJob.Support
             //set email body
             mimeMessage.Body = body;
 
-            using (var client = SmtpOptions.SmtpClient)
+            using (var client = SmtpOptions.InitSmtpClient())
             {
                 try
                 {


### PR DESCRIPTION
lazy一般用在容器中的单例类中,或static字段上
smtpclient不是线程安全的,所以不能作为单例使用, 你的new lazy(InitFunc).value  和 InitFunc() 是一模一样的.
另外 sendemail有异步方法,一般是不建议 Task.Run(()=Lib.Execute()) ,而是直接使用Lib.ExecuteAsync()