### PR TITLE
fix hangfire.client发钉钉消息添加签名密钥

### DIFF
--- a/Client/Hangfire.HttpJob.Client/HttpJobItem.cs
+++ b/Client/Hangfire.HttpJob.Client/HttpJobItem.cs
@@ -109,6 +109,11 @@ namespace Hangfire.HttpJob.Client
         public string Token { get; set; }
 
         /// <summary>
+        /// 钉钉签名密钥
+        /// </summary>
+        public string Secret { get; set; }
+
+        /// <summary>
         /// 通知是否@对应手机号的人员 , 分割
         /// </summary>
         public string AtPhones { get; set; }


### PR DESCRIPTION
钉钉安全策略为密钥签名方式时候, 没有传密钥的字段, 故添加该字段;